### PR TITLE
Fix for hass version 2023.5.x

### DIFF
--- a/custom_components/maika_assistant/__init__.py
+++ b/custom_components/maika_assistant/__init__.py
@@ -178,6 +178,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             DOMAIN, SERVICE_REQUEST_SYNC, request_sync_service_handler
         )
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True


### PR DESCRIPTION
AttributeError: 'ConfigEntries' object has no attribute 'async_setup_platforms'